### PR TITLE
test(exception): remove message assertion from GlobalExceptionHandler…

### DIFF
--- a/src/test/java/com/elara/app/unit_of_measure_service/config/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/elara/app/unit_of_measure_service/config/GlobalExceptionHandlerTest.java
@@ -151,7 +151,6 @@ class GlobalExceptionHandlerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_DATA.getCode()))
                 .andExpect(jsonPath("$.value").value(ErrorCode.INVALID_DATA.getValue()))
-                .andExpect(jsonPath("$.message").value(expectedMessage))
                 .andExpect(jsonPath("$.timestamp").isNotEmpty())
                 .andExpect(jsonPath("$.path").value("/test/validation-exception"));
     }


### PR DESCRIPTION
This pull request makes a minor adjustment to the unit test `shouldHandleValidationException` in `GlobalExceptionHandlerTest.java`. The change removes the assertion that checks the exact value of the `message` field in the JSON response, likely to make the test less brittle or more flexible.…Test