### PR TITLE
Feature/have complete coverage

### DIFF
--- a/src/test/java/com/elara/app/unit_of_measure_service/controller/UomStatusControllerTest.java
+++ b/src/test/java/com/elara/app/unit_of_measure_service/controller/UomStatusControllerTest.java
@@ -387,4 +387,19 @@ class UomStatusControllerTest {
                 .andExpect(jsonPath("$.value").value("INVALID_DATA"));
         }
     }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/uom-status/{id} - deleteUomStatus")
+    class DeleteTests {
+        @Test
+        @DisplayName("should return 204 on success")
+        void delete_shouldReturn204() throws Exception {
+            doNothing().when(service).deleteById(1L);
+
+            mockMvc.perform(delete(BASE_URL + "/{id}", 1))
+                .andExpect(status().isNoContent());
+
+            verify(service).deleteById(1L);
+        }
+    }
 }

--- a/src/test/java/com/elara/app/unit_of_measure_service/service/imp/UomStatusServiceImpTest.java
+++ b/src/test/java/com/elara/app/unit_of_measure_service/service/imp/UomStatusServiceImpTest.java
@@ -132,6 +132,20 @@ class UomStatusServiceImpTest {
         assertThat(result).isEqualTo(response);
     }
 
+    @Test
+    @DisplayName("save() should throw UnexpectedErrorException on generic Exception")
+    void save_shouldThrowUnexpectedErrorOnGenericException() {
+        UomStatusRequest request = new UomStatusRequest("Active", "desc", true);
+        UomStatus entity = UomStatus.builder().name("Active").description("desc").isUsable(true).build();
+        when(service.isNameTaken("Active")).thenReturn(false);
+        when(mapper.toEntity(request)).thenReturn(entity);
+        when(repository.save(entity)).thenThrow(new RuntimeException("boom"));
+
+        assertThatThrownBy(() -> service.save(request))
+                .isInstanceOf(UnexpectedErrorException.class)
+                .hasMessageContaining("boom");
+    }
+
     // --- Update method tests ---
 
     /**
@@ -201,6 +215,21 @@ class UomStatusServiceImpTest {
         assertThatThrownBy(() -> service.update(id, update))
                 .isInstanceOf(UnexpectedErrorException.class)
                 .hasMessageContaining("db error");
+    }
+
+    @Test
+    @DisplayName("update() should throw UnexpectedErrorException on generic Exception")
+    void update_shouldThrowUnexpectedErrorOnGenericException() {
+        Long id = 5L;
+        var update = new UomStatusUpdate("Name", "Desc");
+        var existing = UomStatus.builder().id(id).name("Old Name").description("Old Desc").isUsable(true).build();
+        when(repository.findById(id)).thenReturn(Optional.of(existing));
+        when(service.isNameTaken("Name")).thenReturn(false);
+        doThrow(new RuntimeException("boom")).when(mapper).updateEntityFromDto(existing, update);
+
+        assertThatThrownBy(() -> service.update(id, update))
+                .isInstanceOf(UnexpectedErrorException.class)
+                .hasMessageContaining("boom");
     }
 
     @Test
@@ -297,6 +326,18 @@ class UomStatusServiceImpTest {
         assertThatThrownBy(() -> service.deleteById(id))
                 .isInstanceOf(UnexpectedErrorException.class)
                 .hasMessageContaining("db error");
+    }
+
+    @Test
+    @DisplayName("deleteById() should throw UnexpectedErrorException on generic Exception")
+    void deleteById_shouldThrowUnexpectedErrorOnGenericException() {
+        Long id = 13L;
+        when(repository.existsById(id)).thenReturn(true);
+        doThrow(new RuntimeException("boom")).when(repository).deleteById(id);
+
+        assertThatThrownBy(() -> service.deleteById(id))
+                .isInstanceOf(UnexpectedErrorException.class)
+                .hasMessageContaining("boom");
     }
 
     // --- Find methods tests ---


### PR DESCRIPTION
This pull request adds new unit tests to improve error handling coverage for the `UomStatusServiceImp` service and the `UomStatusController`. The main focus is on verifying that generic exceptions are correctly wrapped as `UnexpectedErrorException` and ensuring the controller's DELETE endpoint behaves as expected.

**Service error handling tests:**

* Added a test to `save()` to verify that a generic exception during entity saving is wrapped and thrown as `UnexpectedErrorException`.
* Added a test to `update()` to verify that a generic exception during entity update is wrapped and thrown as `UnexpectedErrorException`.
* Added a test to `deleteById()` to verify that a generic exception during entity deletion is wrapped and thrown as `UnexpectedErrorException`.

**Controller endpoint tests:**

* Added a nested test class for the DELETE `/api/v1/uom-status/{id}` endpoint, verifying that a successful delete returns HTTP 204 and calls the service correctly.