### PR TITLE
Hotfix/fix http method not supported error message

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -45,7 +45,7 @@ uom.invalid.data=Invalid unit of measure data: {0}
 
 # Parameter & Method Errors
 parameter.missing=Missing required parameter: {0}
-method.not.supported=HTTP method '{0}' is not supported for this endpoint.
+method.not.supported=HTTP method "{0}" is not supported for this endpoint.
 
 # Repository/Database Layer
 # ENTITY_NAME, ERROR_MESSAGE


### PR DESCRIPTION
This pull request makes a minor update to the error message formatting in the `messages.properties` file. The change replaces single quotes with double quotes in the HTTP method error message for consistency.