### PR TITLE
Feature/uom module

### DIFF
--- a/src/main/java/com/elara/app/unit_of_measure_service/controller/UomController.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/controller/UomController.java
@@ -1,0 +1,47 @@
+package com.elara.app.unit_of_measure_service.controller;
+
+import com.elara.app.unit_of_measure_service.dto.request.UomRequest;
+import com.elara.app.unit_of_measure_service.dto.response.UomResponse;
+import com.elara.app.unit_of_measure_service.service.interfaces.UomService;
+import com.elara.app.unit_of_measure_service.service.interfaces.UomStatusService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jdk.swing.interop.SwingInterOpUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/v1/uom", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+@Tag(
+    name = "Uom Management",
+    description = ""
+)
+public class UomController {
+
+    private final UomService service;
+
+    // ========================================
+    // CREATE OPERATIONS
+    // ========================================
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<UomResponse> createUom(@Valid @RequestBody UomRequest request) {
+        log.info("[Uom-controller-create] Request to create Uom: {}.", request);
+        UomResponse response = service.save(request);
+        System.out.println(response);
+        log.info("[Uom-controller-service] Uom created with id: {}.", response.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+}

--- a/src/main/java/com/elara/app/unit_of_measure_service/dto/request/UomRequest.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/dto/request/UomRequest.java
@@ -1,0 +1,27 @@
+package com.elara.app.unit_of_measure_service.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+public record UomRequest(
+
+    @NotBlank
+    @Size(max = 50)
+    String name,
+
+    @Size(max = 200)
+    String description,
+
+    @NotNull
+    @Positive
+    BigDecimal conversionFactorToBase,
+
+    @Positive
+    Long uomStatusId
+
+) {
+}

--- a/src/main/java/com/elara/app/unit_of_measure_service/dto/response/UomResponse.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/dto/response/UomResponse.java
@@ -1,0 +1,14 @@
+package com.elara.app.unit_of_measure_service.dto.response;
+
+import java.math.BigDecimal;
+
+public record UomResponse(
+
+    Long id,
+    String name,
+    String description,
+    BigDecimal conversionFactorToBase,
+    Long uomStatusId
+
+) {
+}

--- a/src/main/java/com/elara/app/unit_of_measure_service/dto/update/UomUpdate.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/dto/update/UomUpdate.java
@@ -1,0 +1,26 @@
+package com.elara.app.unit_of_measure_service.dto.update;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+public record UomUpdate(
+
+    @NotBlank
+    @Size(max = 50)
+    String name,
+
+    @Size(max = 200)
+    String description,
+
+    @NotNull
+    @Positive
+    BigDecimal conversionFactorToBase
+
+    // Deliberately exclude isUsable to force use of changeStatus()
+
+) {
+}

--- a/src/main/java/com/elara/app/unit_of_measure_service/mapper/UomMapper.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/mapper/UomMapper.java
@@ -1,0 +1,22 @@
+package com.elara.app.unit_of_measure_service.mapper;
+
+import com.elara.app.unit_of_measure_service.dto.request.UomRequest;
+import com.elara.app.unit_of_measure_service.dto.response.UomResponse;
+import com.elara.app.unit_of_measure_service.dto.update.UomUpdate;
+import com.elara.app.unit_of_measure_service.model.Uom;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface UomMapper {
+
+    Uom toEntity(UomRequest request);
+
+    UomResponse toResponse(Uom entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "uomStatus", ignore = true)
+    void updateEntityFromDto(@MappingTarget Uom existing, UomUpdate update);
+
+}

--- a/src/main/java/com/elara/app/unit_of_measure_service/model/Uom.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/model/Uom.java
@@ -1,0 +1,44 @@
+package com.elara.app.unit_of_measure_service.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity(name = "uom")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Uom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @NotBlank
+    @Size(max = 50)
+    @Column(name = "name", unique = true, nullable = false, length = 50)
+    private String name;
+
+    @Size(max = 200)
+    @Column(name = "description", length = 200)
+    private String description;
+
+    @NotNull
+    @Positive
+    @Column(name = "conversion_factor_to_base", nullable = false, precision = 10, scale = 3)
+    private BigDecimal conversionFactorToBase;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uom_status_id")
+    private UomStatus uomStatus;
+
+}

--- a/src/main/java/com/elara/app/unit_of_measure_service/repository/UomRepository.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/repository/UomRepository.java
@@ -1,0 +1,20 @@
+package com.elara.app.unit_of_measure_service.repository;
+
+import com.elara.app.unit_of_measure_service.model.Uom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UomRepository extends JpaRepository<Uom, Long> {
+
+    Optional<Uom> findByNameContainingIgnoreCase(String name);
+
+    Page<Uom> findAllByNameContainingIgnoreCase(String name, Pageable pageable);
+
+    Page<Uom> findAllByUomStatusId(Long uomStatusId, Pageable pageable);
+
+    Boolean existsByNameIgnoreCase(String name);
+
+}

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/imp/UomServiceImp.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/imp/UomServiceImp.java
@@ -1,0 +1,56 @@
+package com.elara.app.unit_of_measure_service.service.imp;
+
+import com.elara.app.unit_of_measure_service.dto.request.UomRequest;
+import com.elara.app.unit_of_measure_service.dto.response.UomResponse;
+import com.elara.app.unit_of_measure_service.service.interfaces.UomService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public class UomServiceImp implements UomService {
+
+    @Override
+    public UomResponse save(UomRequest request) {
+        return null;
+    }
+
+    @Override
+    public UomResponse update(Long id, UomRequest request) {
+        return null;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+
+    }
+
+    @Override
+    public UomResponse findById(Long id) {
+        return null;
+    }
+
+    @Override
+    public Page<UomResponse> findAll(Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Page<UomResponse> findAllByName(String name, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Page<UomResponse> findAllByUomStatusId(Long uomStatusId, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Boolean isNameTaken(String name) {
+        return null;
+    }
+
+    @Override
+    public void changeStatus(Long id, Long uomStatusId) {
+
+    }
+
+}

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/interfaces/UomService.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/interfaces/UomService.java
@@ -1,0 +1,28 @@
+package com.elara.app.unit_of_measure_service.service.interfaces;
+
+import com.elara.app.unit_of_measure_service.dto.request.UomRequest;
+import com.elara.app.unit_of_measure_service.dto.response.UomResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UomService {
+
+    UomResponse save(UomRequest request);
+
+    UomResponse update(Long id, UomRequest request);
+
+    void deleteById(Long id);
+
+    UomResponse findById(Long id);
+
+    Page<UomResponse> findAll(Pageable pageable);
+
+    Page<UomResponse> findAllByName(String name, Pageable pageable);
+
+    Page<UomResponse> findAllByUomStatusId(Long uomStatusId, Pageable pageable);
+
+    Boolean isNameTaken(String name);
+
+    void changeStatus(Long id, Long uomStatusId);
+
+}


### PR DESCRIPTION
This pull request introduces the foundational components for the Unit of Measure (UOM) service within the application. It adds the main controller, data transfer objects (DTOs) for requests, responses, and updates, the entity model, a mapper for conversions, the repository interface, and the service interface and its stub implementation. These changes establish the basic structure for creating, updating, retrieving, and managing UOM entities.

### API and Controller Layer
* Added `UomController` to handle UOM creation requests, including input validation and logging.

### Data Transfer Objects (DTOs)
* Introduced `UomRequest`, `UomResponse`, and `UomUpdate` DTOs to define the structure and validation rules for UOM creation, response, and update operations. [[1]](diffhunk://#diff-00883a7e627cc592ff9467c59160d1caedb2babc6af9067aaf9684330f69c13dR1-R27) [[2]](diffhunk://#diff-e29f12b3f87fcc7890612a33bc923ae5edea67f113be09b7749a6469fc630d97R1-R14) [[3]](diffhunk://#diff-ecd0d7b707ee592c618a51c673ee63e97aebcf3419eaf6c5d4e790300354191fR1-R26)

### Domain Model and Mapping
* Created the `Uom` entity model with relevant fields and JPA annotations, and added `UomMapper` for converting between entity and DTOs using MapStruct. [[1]](diffhunk://#diff-72d29fbab998137369fcd639b74f39f9b701ec3be5c648070801f0fd6c7edf5dR1-R44) [[2]](diffhunk://#diff-67916017fc467e70ab942324da289587bc05d6742aa389d874574ec4872463deR1-R22)

### Persistence Layer
* Added `UomRepository` interface for querying UOM entities, including methods for searching by name and status, and checking for name uniqueness.

### Service Layer
* Defined the `UomService` interface and a stub implementation `UomServiceImp` with method signatures for CRUD and status management operations. [[1]](diffhunk://#diff-205b43746d686ef7b2d893864d4bc5e83969b54e40fd5e00a1337e78c5bafae9R1-R28) [[2]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750R1-R56)