### PR TITLE
Feature/refactor not found exception message

### DIFF
--- a/src/main/java/com/elara/app/unit_of_measure_service/service/imp/UomServiceImp.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/imp/UomServiceImp.java
@@ -72,7 +72,7 @@ public class UomServiceImp implements UomService {
                 .orElseThrow(() -> {
                     String msg = messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id);
                     log.warn("[Uom-service-update] {}", msg);
-                    return new ResourceNotFoundException(new Object[]{"id", id.toString()});
+                    return new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
                 });
             if (!existing.getName().equals(request.name()) && Boolean.TRUE.equals(isNameTaken(request.name()))) {
                 String msg = messageService.getMessage("crud.already.exists", ENTITY_NAME, "name", request.name());
@@ -102,7 +102,7 @@ public class UomServiceImp implements UomService {
             log.debug("[Uom-service-deleteById] Attempting to delete {} with id: {}", ENTITY_NAME, id);
             if (!repository.existsById(id)) {
                 log.warn("[Uom-service-deleteById] {}", messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id));
-                throw new ResourceNotFoundException(new Object[]{"id", id.toString()});
+                throw new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
             }
             repository.deleteById(id);
             log.debug("[Uom-service-deleteById] {} with id: {}", messageService.getMessage("crud.delete.success", ENTITY_NAME), id);
@@ -124,7 +124,7 @@ public class UomServiceImp implements UomService {
             .map(mapper::toResponse);
         if (response.isEmpty()) {
             log.warn("[Uom-service-findById] {}", messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id));
-            throw new ResourceNotFoundException(new Object[]{"id", id.toString()});
+            throw new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
         }
         log.debug("[Uom-service-findById] {}", messageService.getMessage("crud.read.success", ENTITY_NAME));
         return response.get();
@@ -171,7 +171,7 @@ public class UomServiceImp implements UomService {
                 .orElseThrow(() -> {
                     String msg = messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id);
                     log.warn("[Uom-service-changeStatus] {} - Entity not found for id: {}", msg, id);
-                    return new ResourceNotFoundException(new Object[]{"id", id.toString()});
+                    return new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
                 });
             Long oldStatusId = existing.getUomStatus().getId();
             UomStatus newStatus = statusService.findByIdService(uomStatusId);

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/imp/UomStatusServiceImp.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/imp/UomStatusServiceImp.java
@@ -91,7 +91,7 @@ public class UomStatusServiceImp implements UomStatusService {
         UomStatus existing = repository.findById(id)
             .orElseThrow(() -> {
                 log.warn("[UomStatus-service-update] {}", messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id));
-                return new ResourceNotFoundException(new Object[]{"id", id.toString()});
+                return new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
             });
 
         if (!existing.getName().equals(request.name()) && Boolean.TRUE.equals(isNameTaken(request.name()))) {
@@ -127,7 +127,7 @@ public class UomStatusServiceImp implements UomStatusService {
         log.debug("[UomStatus-service-deleteById] Attempting to delete {} with id: {}", ENTITY_NAME, id);
         if (!repository.existsById(id)) {
             log.warn("[UomStatus-service-deleteById] {}", messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id));
-            throw new ResourceNotFoundException(new Object[]{"id", id.toString()});
+            throw new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
         }
         try {
             repository.deleteById(id);
@@ -156,7 +156,7 @@ public class UomStatusServiceImp implements UomStatusService {
             .map(mapper::toResponse);
         if (response.isEmpty()) {
             log.warn("[UomStatus-service-findById] {}", messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id));
-            throw new ResourceNotFoundException(new Object[]{"id", id.toString()});
+            throw new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
         }
         log.debug("[UomStatus-service-findById] {}", messageService.getMessage("crud.read.success", ENTITY_NAME));
         return response.get();
@@ -168,7 +168,7 @@ public class UomStatusServiceImp implements UomStatusService {
         UomStatus entity = repository.findById(id)
             .orElseThrow(() -> {
                 log.warn("[UomStatus-service-findByIdService] {}", messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id));
-                return new ResourceNotFoundException(new Object[]{"id", id.toString()});
+                return new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
             });
         log.debug("[UomStatus-service-findByIdService] {}", messageService.getMessage("crud.read.success", ENTITY_NAME));
         return entity;
@@ -246,7 +246,7 @@ public class UomStatusServiceImp implements UomStatusService {
         UomStatus existing = repository.findById(id)
             .orElseThrow(() -> {
                 log.warn("[changeStatus] {} - Entity not found for id: {}", messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id), id);
-                return new ResourceNotFoundException(new Object[]{"id", id.toString()});
+                return new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
             });
         Boolean oldStatus = existing.getIsUsable();
         existing.setIsUsable(isUsable);

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -3,7 +3,7 @@ global.success.operation=Operation completed successfully.
 global.error.unexpected=An unexpected error occurred. Please contact support.
 global.error.database=Database error: {0}
 global.error.service.unavailable=Service is temporarily unavailable. Please try again later.
-global.error.not.found=Resource not found, when: "{0} = {1}".
+global.error.not.found={0} not found, when: "{1} = {2}".
 global.error.conflict=Conflict detected, when: "{0} = {1}".
 global.error.unauthorized=You are not authorized to perform this action.
 global.error.forbidden=Access to this resource is forbidden.


### PR DESCRIPTION
This pull request updates how resource not found errors are handled in both the `UomServiceImp` and `UomStatusServiceImp` classes to provide more consistent and informative error messages. The changes ensure that the entity name is included in the exception parameters and that the corresponding error message template in `messages.properties` is updated to match this new format.

**Error handling improvements:**

* Updated all instances where `ResourceNotFoundException` is thrown in `UomServiceImp.java` and `UomStatusServiceImp.java` to include the entity name as the first parameter, improving error context for not found exceptions. [[1]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750L75-R75) [[2]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750L105-R105) [[3]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750L127-R127) [[4]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750L174-R174) [[5]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL94-R94) [[6]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL130-R130) [[7]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL159-R159) [[8]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL171-R171) [[9]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL249-R249)

**Localization/message consistency:**

* Updated the `global.error.not.found` template in `messages.properties` to expect the entity name as the first argument, ensuring error messages are clearer and consistent across the application.This pull request standardizes how resource not found errors are thrown and improves error messaging for both Unit of Measure and Unit of Measure Status services. The main change is to consistently include the entity name in the `ResourceNotFoundException` constructor, ensuring clearer error context throughout the codebase. Additionally, the error message format in `messages.properties` has been updated to better reflect which entity was not found.

**Error handling improvements:**

* Updated all occurrences of `ResourceNotFoundException` in `UomServiceImp.java` and `UomStatusServiceImp.java` to include the entity name as the first argument, improving error context for not found exceptions. [[1]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750L75-R75) [[2]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750L105-R105) [[3]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750L127-R127) [[4]](diffhunk://#diff-1f2f8b6c3118de8889302e6ff963edd55ec2ffad2337f25e9116aff4dcbf7750L174-R174) [[5]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL94-R94) [[6]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL130-R130) [[7]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL159-R159) [[8]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL171-R171) [[9]](diffhunk://#diff-3be6ca3ff7ea439a18dc3aadf8a820c72704c527705861be335b587994c8438dL249-R249)

**Error message clarity:**

* Changed the `global.error.not.found` message in `messages.properties` to include the entity name (`{0} not found, when: "{1} = {2}"`) for clearer error reporting.