### PR TITLE
feat(config): add Spring Cloud Config and set active profile in appli…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
 
         <!-- Runtime dependencies -->
         <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  profiles:
+    active: dev
+  config:
+    import: optional:configserver:http://localhost:8888
   application:
     name: unit-of-measure-service
   datasource:


### PR DESCRIPTION
This pull request introduces support for externalized configuration management using Spring Cloud Config. The main changes involve updating the project dependencies and configuration to enable the service to fetch its configuration from a centralized config server.

Configuration management enhancements:

* Added the `spring-cloud-starter-config` dependency to `pom.xml` to enable Spring Cloud Config support.
* Updated `application.yml` to activate the `dev` profile and configure the service to import configuration from a local config server at `http://localhost:8888`.…cation.yml