### PR TITLE
Feature/vault config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-vault-config</artifactId>
+        </dependency>
 
         <!-- Runtime dependencies -->
         <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,13 +2,19 @@ spring:
   profiles:
     active: dev
   config:
-    import: optional:configserver:http://localhost:8888
+    import:
+    - optional:configserver:http://localhost:8888
+    - vault://secret/unit-of-measure-service/dev
+  cloud:
+    vault:
+      application-name: ${spring.application.name}
+      uri: http://localhost:8200
+      authentication: TOKEN
+      token: 00000000-0000-0000-0000-000000000000
   application:
     name: unit-of-measure-service
   datasource:
-    url: ${DB_URL:}
-    username: ${DB_USERNAME:}
-    password: ${DB_PASSWORD:}
+    url: jdbc:postgresql://localhost:5432/unit_of_measure_db
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
@@ -31,4 +37,4 @@ eureka:
       region: us-east # Custom metadata: region/location of the service
   client:
     service-url:
-      defaultZone: ${EUREKA_URL:} # Eureka server URL for service registration and discovery
+      defaultZone: http://localhost:8761/eureka/ # Eureka server URL for service registration and discovery


### PR DESCRIPTION
This pull request introduces integration with HashiCorp Vault for secure configuration management, updates the application to use local service endpoints for development, and refines configuration loading in `application.yml`. The most significant changes are grouped below.

**Vault Integration and Configuration Management:**

* Added the `spring-cloud-starter-vault-config` dependency to `pom.xml` to enable Vault support in the Spring application.
* Updated `application.yml` to import configuration from Vault (`vault://secret/unit-of-measure-service/dev`) and configured Vault connection properties, including URI, authentication method, and token.

**Development Environment Defaults:**

* Changed the datasource URL in `application.yml` to use a local PostgreSQL instance, simplifying local development setup.
* Set the Eureka service URL to a local endpoint (`http://localhost:8761/eureka/`) for easier service registration and discovery during development.