### PR TITLE
Feature/check pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <lombok.version>1.18.38</lombok.version>
         <jacoco.version>0.8.12</jacoco.version>
         <mapstruct.version>1.6.3</mapstruct.version>
+        <springdoc.openapi.version>2.8.0</springdoc.openapi.version>
+        <spring-cloud.version>2025.0.0</spring-cloud.version>
         <!-- + + + + -->
         <sonar.scanner.version>5.1.0.4751</sonar.scanner.version>
         <sonar.projectKey>com.elara.app:unit-of-measure-service</sonar.projectKey>
@@ -62,8 +64,6 @@
         <sonar.exclusions>
             **/UnitOfMeasureServiceApplication.java
         </sonar.exclusions>
-        <springdoc.openapi.version>2.8.0</springdoc.openapi.version>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,10 @@
         <maven.surefire.version>3.5.3</maven.surefire.version>
         <lombok.version>1.18.38</lombok.version>
         <jacoco.version>0.8.12</jacoco.version>
-        <sonar.scanner.version>5.1.0.4751</sonar.scanner.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <!-- + + + + -->
-        <sonar.language>java</sonar.language>
+        <sonar.scanner.version>5.1.0.4751</sonar.scanner.version>
         <sonar.projectKey>com.elara.app:unit-of-measure-service</sonar.projectKey>
-        <sonar.host.url>http://localhost:9000</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <sonar.exclusions>
             **/UnitOfMeasureServiceApplication.java

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             **/UnitOfMeasureServiceApplication.java
         </sonar.exclusions>
     </properties>
+
+    <!--
+        dependencyManagement section is used to centralize and manage versions of dependencies.
+        The spring-cloud-dependencies BOM (Bill of Materials) ensures consistent versions for all Spring Cloud components.
+        By importing this BOM, you avoid version conflicts and simplify dependency upgrades.
+    -->
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -247,12 +247,14 @@
                                         </limit>
                                     </limits>
                                     <excludes>
-                                        <exclude>com.elara.app.UnitOfMeasureServiceApplication.configuration.*</exclude>
+                                        <exclude>com.elara.app.UnitOfMeasureServiceApplication.config.*</exclude>
+                                        <exclude>com.elara.app.unit_of_measure_service.UnitOfMeasureServiceApplication</exclude>
                                     </excludes>
                                 </rule>
                             </rules>
                             <excludes>
                                 <exclude>**/UnitOfMeasureServiceApplication.class</exclude>
+                                <exclude>**/config/**</exclude>
                                 <exclude>**/dto/**</exclude>
                             </excludes>
                         </configuration>
@@ -263,6 +265,7 @@
                     <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
                     <excludes>
                         <exclude>**/UnitOfMeasureServiceApplication.class</exclude>
+                        <exclude>**/config/**</exclude>
                         <exclude>**/dto/**</exclude>
                     </excludes>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,7 @@
     <!-- - - - - - - - - - - - - -->
     <properties>
         <java.version>21</java.version>
-        <maven.compiler.version>3.14.0</maven.compiler.version>
-        <maven.surefire.version>3.5.3</maven.surefire.version>
+        <maven.compiler.release>21</maven.compiler.release>
         <lombok.version>1.18.38</lombok.version>
         <jacoco.version>0.8.12</jacoco.version>
         <mapstruct.version>1.6.3</mapstruct.version>
@@ -157,8 +156,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.version}</version>
                 <configuration>
+                    <release>${maven.compiler.release}</release>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <maven.compiler.version>3.14.0</maven.compiler.version>
         <maven.surefire.version>3.5.3</maven.surefire.version>
         <lombok.version>1.18.38</lombok.version>
-        <postgresql.version>42.7.7</postgresql.version>
         <jacoco.version>0.8.12</jacoco.version>
         <sonar.scanner.version>5.1.0.4751</sonar.scanner.version>
         <mapstruct.version>1.6.3</mapstruct.version>
@@ -130,7 +129,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <maven.compiler.version>3.14.0</maven.compiler.version>
         <maven.surefire.version>3.5.3</maven.surefire.version>
         <lombok.version>1.18.38</lombok.version>
-        <h2.version>2.3.232</h2.version>
         <postgresql.version>42.7.7</postgresql.version>
         <jacoco.version>0.8.12</jacoco.version>
         <sonar.scanner.version>5.1.0.4751</sonar.scanner.version>
@@ -134,14 +133,13 @@
             <version>${postgresql.version}</version>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>${h2.version}</version>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
-
-        <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <java.version>21</java.version>
         <maven.compiler.release>21</maven.compiler.release>
         <lombok.version>1.18.38</lombok.version>
-        <jacoco.version>0.8.12</jacoco.version>
+        <jacoco.version>0.8.14</jacoco.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <springdoc.openapi.version>2.8.0</springdoc.openapi.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-bus-amqp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.openapi.version}</version>
+        </dependency>
 
         <!-- Runtime dependencies -->
         <dependency>
@@ -145,12 +150,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- OpenAPI/Swagger dependencies -->
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>${springdoc.openapi.version}</version>
-        </dependency>
     </dependencies>
 
     <!-- - - - - - - - - - - - - -->

--- a/pom.xml
+++ b/pom.xml
@@ -120,15 +120,16 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-bus-amqp</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
 
         <!-- Runtime dependencies -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
This pull request updates the Maven build configuration in `pom.xml` to improve dependency management, clarify test/runtime dependencies, and enhance code coverage settings. The main changes focus on modernizing dependency versions, reorganizing dependencies for clarity, and refining code coverage exclusions.

**Dependency management and modernization:**

* Replaced specific dependency versions with a centralized `dependencyManagement` section, importing the Spring Cloud BOM to ensure consistent versions and easier upgrades for Spring Cloud components.
* Updated the JaCoCo code coverage plugin version from `0.8.12` to `0.8.14` for improved coverage analysis.

**Dependency reorganization and clarification:**

* Swapped the order of the Actuator and SpringDoc OpenAPI dependencies, making `springdoc-openapi-starter-webmvc-ui` a main dependency and moving `spring-boot-starter-actuator` to runtime. Also, moved the H2 database dependency to the test scope for clarity and removed explicit version tags for H2 and PostgreSQL, relying on BOM-managed versions.
* Updated the Maven compiler plugin configuration to use the `release` property instead of specifying a plugin version, aligning with modern Java build practices.

**Code coverage and reporting:**

* Refined JaCoCo coverage exclusions to more accurately exclude configuration and DTO classes, including new patterns for config packages and the main application class. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L251-R257) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R268)