### PR TITLE
Feature/refactor general technical debt

### DIFF
--- a/src/main/java/com/elara/app/unit_of_measure_service/controller/UomStatusController.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/controller/UomStatusController.java
@@ -29,7 +29,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping(value = "states/", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "status/", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 @Validated
 @Slf4j
@@ -41,7 +41,7 @@ import org.springframework.web.bind.annotation.*;
 )
 public class UomStatusController {
 
-    private static final String ENTITY_NAME = "State";
+    private static final String ENTITY_NAME = "UomStatus";
     private static final String NOMENCLATURE = ENTITY_NAME + "-controller";
     private final UomStatusService service;
     private final MessageService messageService;
@@ -161,7 +161,7 @@ public class UomStatusController {
                 - Partial string matching (e.g., 'act' finds 'Active')
                 - Results support pagination and sorting
                 
-                **Example:** `/states/search?name=act&page=0&size=20`""")
+                **Example:** `/status/search?name=act&page=0&size=20`""")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Search completed successfully - Returns matching statuses",
             content = @Content(schema = @Schema(ref = "#/components/schemas/UomStatusPageResponse"),
@@ -195,7 +195,7 @@ public class UomStatusController {
                 - `isUsable=false`: Returns only non-usable statuses
                 - Results support pagination and sorting
                 
-                **Example:** `/states/filter?isUsable=true&page=0&size=20`""")
+                **Example:** `/status/filter?isUsable=true&page=0&size=20`""")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Filtering completed successfully - Returns filtered statuses",
             content = @Content(schema = @Schema(ref = "#/components/schemas/UomStatusPageResponse"),
@@ -228,7 +228,7 @@ public class UomStatusController {
                 - `true`: Name is already taken (not available)
                 - `false`: Name is available and can be used
                 
-                **Example:** `/states/check-name?name=Active`""")
+                **Example:** `/status/check-name?name=Active`""")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Check completed successfully - Returns boolean (true=taken, false=available)",
             content = @Content(schema = @Schema(type = "boolean"),
@@ -258,7 +258,7 @@ public class UomStatusController {
         description = """
                 Updates an existing UOM Status record.
                 
-                **Important:** The `isUsable` field cannot be changed using this endpoint. Use the dedicated `/states/{id}/change-usability` endpoint to modify the usability status.
+                **Important:** The `isUsable` field cannot be changed using this endpoint. Use the dedicated `/status/{id}/change-usability` endpoint to modify the usability status.
                 
                 **Updatable Fields:**
                 - `name`: New status name (1-50 chars, optional)
@@ -316,7 +316,7 @@ public class UomStatusController {
                 - `id`: Status identifier (positive integer)
                 - `isUsable`: New usability status (required boolean)
                 
-                **Example:** `PATCH /states/1/change-usability/?isUsable=false`""")
+                **Example:** `PATCH /status/1/change-usability/?isUsable=false`""")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Status changed successfully - No content returned"),
         @ApiResponse(responseCode = "400", description = "Bad Request - Invalid ID format or missing isUsable parameter",

--- a/src/main/java/com/elara/app/unit_of_measure_service/model/Uom.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/model/Uom.java
@@ -37,6 +37,7 @@ public class Uom {
     @Column(name = "conversion_factor_to_base", nullable = false, precision = 10, scale = 3)
     private BigDecimal conversionFactorToBase;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uom_status_id")
     private UomStatus uomStatus;

--- a/src/main/java/com/elara/app/unit_of_measure_service/repository/UomRepository.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/repository/UomRepository.java
@@ -15,6 +15,6 @@ public interface UomRepository extends JpaRepository<Uom, Long> {
 
     Page<Uom> findAllByUomStatusId(Long uomStatusId, Pageable pageable);
 
-    Boolean existsByNameIgnoreCase(String name);
+    boolean existsByNameIgnoreCase(String name);
 
 }

--- a/src/main/java/com/elara/app/unit_of_measure_service/repository/UomStatusRepository.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/repository/UomStatusRepository.java
@@ -17,6 +17,6 @@ public interface UomStatusRepository extends JpaRepository<UomStatus, Long> {
 
     Page<UomStatus> findAllByIsUsable(Boolean isUsable, Pageable pageable);
 
-    Boolean existsByName(String name);
+    boolean existsByName(String name);
 
 }

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomServiceImp.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomServiceImp.java
@@ -40,13 +40,13 @@ public class UomServiceImp implements UomService {
         final String methodNomenclature = NOMENCLATURE + "-save";
         log.info("[{}] {} record to save: {}", methodNomenclature, ENTITY_NAME, request);
         try {
-            if (Boolean.TRUE.equals(isNameTaken(Objects.requireNonNull(request).name()))) {
+            if (isNameTaken(Objects.requireNonNull(request).name())) {
                 String alreadyExistsMsg = messageService.getMessage("crud.already.exists", ENTITY_NAME, "name", request.name());
                 log.warn("[{}] {}", methodNomenclature, alreadyExistsMsg);
                 throw new ResourceConflictException(alreadyExistsMsg);
             }
             Uom entity = mapper.toEntity(request);
-            UomStatus status = statusService.findByIdService(request.uomStatusId());
+            UomStatus status = statusService.findEntityById(request.uomStatusId());
             entity.setUomStatus(status); // This can be avoided using @Context in the mapper and receive the request and UomStatus as parameters
             Uom saved = repository.save(entity);
             log.info("[{}] {} record created with id: {}.", methodNomenclature, ENTITY_NAME, saved.getId());
@@ -70,7 +70,7 @@ public class UomServiceImp implements UomService {
                     log.warn("[{}] {}", methodNomenclature, msg);
                     return new ResourceNotFoundException(msg);
                 });
-            if (!existing.getName().equals(request.name()) && Boolean.TRUE.equals(isNameTaken(request.name()))) {
+            if (!existing.getName().equals(request.name()) && isNameTaken(request.name())) {
                 String alreadyExistsMsg = messageService.getMessage("crud.already.exists", ENTITY_NAME, "name", request.name());
                 log.warn("[{}] {}", methodNomenclature, alreadyExistsMsg);
                 throw new ResourceConflictException(alreadyExistsMsg);
@@ -154,10 +154,10 @@ public class UomServiceImp implements UomService {
     }
 
     @Override
-    public Boolean isNameTaken(String name) {
+    public boolean isNameTaken(String name) {
         final String methodNomenclature = NOMENCLATURE + "-isNameTaken";
         log.info("[{}] Check if name '{}' is taken.", methodNomenclature, name);
-        Boolean exists = repository.existsByNameIgnoreCase(name);
+        boolean exists = repository.existsByNameIgnoreCase(name);
         log.info("[{}] Name '{}' {} taken.", methodNomenclature, name, exists ? "is" : "is not");
         return exists;
     }
@@ -174,7 +174,7 @@ public class UomServiceImp implements UomService {
                     log.warn("[{}] {}", methodNomenclature, msg);
                     return new ResourceNotFoundException(msg);
                 });
-            UomStatus newStatus = statusService.findByIdService(uomStatusId);
+            UomStatus newStatus = statusService.findEntityById(uomStatusId);
             existing.setUomStatus(newStatus);
             log.info("[{}] Changed status id of {} record with id: {} to: {}", methodNomenclature, ENTITY_NAME, id, newStatus.getId());
             return mapper.toResponse(existing);

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomServiceImp.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomServiceImp.java
@@ -12,12 +12,12 @@ import com.elara.app.unit_of_measure_service.repository.UomRepository;
 import com.elara.app.unit_of_measure_service.service.interfaces.UomService;
 import com.elara.app.unit_of_measure_service.service.interfaces.UomStatusService;
 import com.elara.app.unit_of_measure_service.utils.MessageService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -107,6 +107,7 @@ public class UomServiceImp implements UomService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public UomResponse findById(Long id) {
         final String methodNomenclature = NOMENCLATURE + "-findById";
         log.info("[{}] Fetch {} record with id: {}", methodNomenclature, ENTITY_NAME, id);
@@ -127,6 +128,7 @@ public class UomServiceImp implements UomService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<UomResponse> findAll(Pageable pageable) {
         final String methodNomenclature = NOMENCLATURE + "-findAll";
         log.info("[{}] Fetch all {} records.", methodNomenclature, ENTITY_NAME);
@@ -136,6 +138,7 @@ public class UomServiceImp implements UomService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<UomResponse> findAllByName(String name, Pageable pageable) {
         final String methodNomenclature = NOMENCLATURE + "-findAllByName";
         log.info("[{}] Fetch all {} records that contain in their name: '{}'", methodNomenclature, ENTITY_NAME, name);
@@ -145,6 +148,7 @@ public class UomServiceImp implements UomService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<UomResponse> findAllByUomStatusId(Long uomStatusId, Pageable pageable) {
         final String methodNomenclature = NOMENCLATURE + "-findAllByUomStatusId";
         log.info("[{}] Fetch all {} records with status id: '{}'", methodNomenclature, ENTITY_NAME, uomStatusId);

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomStatusServiceImp.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomStatusServiceImp.java
@@ -10,12 +10,12 @@ import com.elara.app.unit_of_measure_service.model.UomStatus;
 import com.elara.app.unit_of_measure_service.repository.UomStatusRepository;
 import com.elara.app.unit_of_measure_service.service.interfaces.UomStatusService;
 import com.elara.app.unit_of_measure_service.utils.MessageService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -135,7 +135,7 @@ public class UomStatusServiceImp implements UomStatusService {
      * @return an Optional containing the found UomStatusResponse, or empty if not found
      * @throws ResourceNotFoundException if no UomStatus found with the given id
      */
-    @Override
+    @Override @Transactional(readOnly = true)
     public UomStatusResponse findById(Long id) {
         final String methodNomenclature = NOMENCLATURE + "-findById";
         log.info("[{}] Fetch {} record with id: {}", methodNomenclature, ENTITY_NAME, id);
@@ -170,6 +170,7 @@ public class UomStatusServiceImp implements UomStatusService {
      * @return a page of UomStatusResponse
      */
     @Override
+    @Transactional(readOnly = true)
     public Page<UomStatusResponse> findAll(Pageable pageable) {
         final String methodNomenclature = NOMENCLATURE + "-findAll";
         log.info("[{}] Fetch all {} records.", methodNomenclature, ENTITY_NAME);
@@ -186,6 +187,7 @@ public class UomStatusServiceImp implements UomStatusService {
      * @return a page of UomStatusResponse
      */
     @Override
+    @Transactional(readOnly = true)
     public Page<UomStatusResponse> findAllByName(String name, Pageable pageable) {
         final String methodNomenclature = NOMENCLATURE + "-findAllByName";
         log.info("[{}] Fetch all {} records that contain in their name: '{}'", methodNomenclature, ENTITY_NAME, name);
@@ -202,6 +204,7 @@ public class UomStatusServiceImp implements UomStatusService {
      * @return a page of UomStatusResponse
      */
     @Override
+    @Transactional(readOnly = true)
     public Page<UomStatusResponse> findAllByIsUsable(Boolean isUsable, Pageable pageable) {
         final String methodNomenclature = NOMENCLATURE + "-findAllByIsUsable";
         log.info("[{}] Fetch all {} records with isUsable: {}.", methodNomenclature, ENTITY_NAME, isUsable);

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomStatusServiceImp.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomStatusServiceImp.java
@@ -149,6 +149,7 @@ public class UomStatusServiceImp implements UomStatusService {
         return mapper.toResponse(entity.get());
     }
 
+    @Override
     @Transactional
     public UomStatus findEntityById(Long id) {
         final String methodNomenclature = NOMENCLATURE + "-findEntityById";
@@ -219,6 +220,7 @@ public class UomStatusServiceImp implements UomStatusService {
      * @param name the name of the UomStatus to check
      * @return true if exists, false otherwise
      */
+    @Override
     public boolean isNameTaken(String name) {
         final String methodNomenclature = NOMENCLATURE + "-isNameTaken";
         log.info("[{}] Check if name '{}' is taken.", methodNomenclature, name);

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomStatusServiceImp.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/implementation/UomStatusServiceImp.java
@@ -50,7 +50,7 @@ public class UomStatusServiceImp implements UomStatusService {
     public UomStatusResponse save(UomStatusRequest request) {
         final String methodNomenclature = NOMENCLATURE + "-save";
         log.info("[{}] {} record to save: {}", methodNomenclature, ENTITY_NAME, request);
-        if (Boolean.TRUE.equals(isNameTaken(Objects.requireNonNull(request).name()))) {
+        if (isNameTaken(Objects.requireNonNull(request).name())) {
             String alreadyExistsMsg = messageService.getMessage("crud.already.exists", ENTITY_NAME, "name", request.name());
             String saveErrorMsg = messageService.getMessage("crud.save.error", ENTITY_NAME);
             log.warn("[{}] {}", methodNomenclature, alreadyExistsMsg);
@@ -89,7 +89,7 @@ public class UomStatusServiceImp implements UomStatusService {
                     log.warn("[{}] {}", methodNomenclature, updateErrorMsg);
                     return new ResourceNotFoundException(notFoundMsg);
                 });
-            if (!existing.getName().equals(request.name()) && Boolean.TRUE.equals(isNameTaken(request.name()))) {
+            if (!existing.getName().equals(request.name()) && isNameTaken(request.name())) {
                 String alreadyExistsMsg = messageService.getMessage("crud.already.exists", ENTITY_NAME, "name", request.name());
                 log.warn("[{}] {}", methodNomenclature, alreadyExistsMsg);
                 throw new ResourceConflictException(alreadyExistsMsg);
@@ -150,8 +150,8 @@ public class UomStatusServiceImp implements UomStatusService {
     }
 
     @Transactional
-    public UomStatus findByIdService(Long id) {
-        final String methodNomenclature = NOMENCLATURE + "-findByIdService";
+    public UomStatus findEntityById(Long id) {
+        final String methodNomenclature = NOMENCLATURE + "-findEntityById";
         log.info("[{}] Fetch {} record with id: {}", methodNomenclature, ENTITY_NAME, id);
         UomStatus entity = repository.findById(id)
             .orElseThrow(() -> {
@@ -216,10 +216,10 @@ public class UomStatusServiceImp implements UomStatusService {
      * @param name the name of the UomStatus to check
      * @return true if exists, false otherwise
      */
-    public Boolean isNameTaken(String name) {
+    public boolean isNameTaken(String name) {
         final String methodNomenclature = NOMENCLATURE + "-isNameTaken";
         log.info("[{}] Check if name '{}' is taken.", methodNomenclature, name);
-        Boolean exists = repository.existsByName(name);
+        boolean exists = repository.existsByName(name);
         log.info("[{}] Name '{}' {} taken.", methodNomenclature, name, exists ? "is" : "is not");
         return exists;
     }

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/interfaces/UomService.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/interfaces/UomService.java
@@ -22,7 +22,7 @@ public interface UomService {
 
     Page<UomResponse> findAllByUomStatusId(Long uomStatusId, Pageable pageable);
 
-    Boolean isNameTaken(String name);
+    boolean isNameTaken(String name);
 
     UomResponse changeStatus(Long id, Long uomStatusId);
 

--- a/src/main/java/com/elara/app/unit_of_measure_service/service/interfaces/UomStatusService.java
+++ b/src/main/java/com/elara/app/unit_of_measure_service/service/interfaces/UomStatusService.java
@@ -17,7 +17,7 @@ public interface UomStatusService {
 
     UomStatusResponse findById(Long id);
 
-    UomStatus findByIdService(Long id);
+    UomStatus findEntityById(Long id);
 
     Page<UomStatusResponse> findAll(Pageable pageable);
 
@@ -25,7 +25,7 @@ public interface UomStatusService {
 
     Page<UomStatusResponse> findAllByIsUsable(Boolean isUsable, Pageable pageable);
 
-    Boolean isNameTaken(String name);
+    boolean isNameTaken(String name);
 
     void changeStatus(Long id, Boolean isUsable);
 

--- a/src/test/java/com/elara/app/unit_of_measure_service/repository/UomRepositoryTest.java
+++ b/src/test/java/com/elara/app/unit_of_measure_service/repository/UomRepositoryTest.java
@@ -231,7 +231,7 @@ class UomRepositoryTest {
             createAndPersistUom("Kilogram", "Base unit", new BigDecimal("1.000"), activeStatus);
 
             // When
-            Boolean exists = repository.existsByNameIgnoreCase("Kilogram");
+            boolean exists = repository.existsByNameIgnoreCase("Kilogram");
 
             // Then
             assertThat(exists).isTrue();
@@ -244,7 +244,7 @@ class UomRepositoryTest {
             createAndPersistUom("Kilogram", "Base unit", new BigDecimal("1.000"), activeStatus);
 
             // When
-            Boolean exists = repository.existsByNameIgnoreCase("Liter");
+            boolean exists = repository.existsByNameIgnoreCase("Liter");
 
             // Then
             assertThat(exists).isFalse();
@@ -257,9 +257,9 @@ class UomRepositoryTest {
             createAndPersistUom("Kilogram", "Base unit", new BigDecimal("1.000"), activeStatus);
 
             // When
-            Boolean existsLower = repository.existsByNameIgnoreCase("kilogram");
-            Boolean existsUpper = repository.existsByNameIgnoreCase("KILOGRAM");
-            Boolean existsMixed = repository.existsByNameIgnoreCase("KiLoGrAm");
+            boolean existsLower = repository.existsByNameIgnoreCase("kilogram");
+            boolean existsUpper = repository.existsByNameIgnoreCase("KILOGRAM");
+            boolean existsMixed = repository.existsByNameIgnoreCase("KiLoGrAm");
 
             // Then
             assertThat(existsLower).isTrue();

--- a/src/test/java/com/elara/app/unit_of_measure_service/service/implementation/UomServiceImpTest.java
+++ b/src/test/java/com/elara/app/unit_of_measure_service/service/implementation/UomServiceImpTest.java
@@ -69,7 +69,7 @@ class UomServiceImpTest {
 
             doReturn(false).when(service).isNameTaken("Kilogram");
             when(mapper.toEntity(request)).thenReturn(entity);
-            when(statusService.findByIdService(1L)).thenReturn(status);
+            when(statusService.findEntityById(1L)).thenReturn(status);
             when(repository.save(entity)).thenReturn(saved);
             when(mapper.toResponse(saved)).thenReturn(response);
 
@@ -79,7 +79,7 @@ class UomServiceImpTest {
             // Then
             assertThat(result).isEqualTo(response);
             verify(repository).save(entity);
-            verify(statusService).findByIdService(1L);
+            verify(statusService).findEntityById(1L);
             verify(mapper).toResponse(saved);
         }
 
@@ -109,7 +109,7 @@ class UomServiceImpTest {
             
             doReturn(false).when(service).isNameTaken("Kilogram");
             when(mapper.toEntity(request)).thenReturn(entity);
-            when(statusService.findByIdService(999L)).thenThrow(new ResourceNotFoundException("Uom not found, when: \"id = 999\"."));
+            when(statusService.findEntityById(999L)).thenThrow(new ResourceNotFoundException("Uom not found, when: \"id = 999\"."));
 
             // When & Then
             assertThatThrownBy(() -> service.save(request))
@@ -130,7 +130,7 @@ class UomServiceImpTest {
 
             doReturn(false).when(service).isNameTaken("Gram");
             when(mapper.toEntity(request)).thenReturn(entity);
-            when(statusService.findByIdService(1L)).thenReturn(status);
+            when(statusService.findEntityById(1L)).thenReturn(status);
             when(repository.save(entity)).thenReturn(saved);
             when(mapper.toResponse(saved)).thenReturn(response);
 
@@ -138,7 +138,7 @@ class UomServiceImpTest {
             service.save(request);
 
             // Then
-            verify(statusService).findByIdService(1L);
+            verify(statusService).findEntityById(1L);
             verify(repository).save(argThat(uom -> uom.getUomStatus() != null && uom.getUomStatus().getId().equals(1L)));
         }
 
@@ -481,7 +481,7 @@ class UomServiceImpTest {
             when(repository.existsByNameIgnoreCase(name)).thenReturn(true);
 
             // When
-            Boolean result = service.isNameTaken(name);
+            boolean result = service.isNameTaken(name);
 
             // Then
             assertThat(result).isTrue();
@@ -496,7 +496,7 @@ class UomServiceImpTest {
             when(repository.existsByNameIgnoreCase(name)).thenReturn(false);
 
             // When
-            Boolean result = service.isNameTaken(name);
+            boolean result = service.isNameTaken(name);
 
             // Then
             assertThat(result).isFalse();
@@ -528,7 +528,7 @@ class UomServiceImpTest {
             Uom existing = Uom.builder().id(uomId).name("Kilogram").uomStatus(oldStatus).build();
 
             when(repository.findById(uomId)).thenReturn(Optional.of(existing));
-            when(statusService.findByIdService(statusId)).thenReturn(newStatus);
+            when(statusService.findEntityById(statusId)).thenReturn(newStatus);
 
             // When
             service.changeStatus(uomId, statusId);
@@ -536,7 +536,7 @@ class UomServiceImpTest {
             // Then
             assertThat(existing.getUomStatus()).isEqualTo(newStatus);
             verify(repository).findById(uomId);
-            verify(statusService).findByIdService(statusId);
+            verify(statusService).findEntityById(statusId);
         }
 
         @Test
@@ -554,7 +554,7 @@ class UomServiceImpTest {
             assertThatThrownBy(() -> service.changeStatus(uomId, statusId))
                     .isInstanceOf(ResourceNotFoundException.class);
             
-            verify(statusService, never()).findByIdService(any());
+            verify(statusService, never()).findEntityById(any());
         }
 
         @Test
@@ -567,7 +567,7 @@ class UomServiceImpTest {
             Uom existing = Uom.builder().id(uomId).name("Kilogram").uomStatus(oldStatus).build();
 
             when(repository.findById(uomId)).thenReturn(Optional.of(existing));
-            when(statusService.findByIdService(statusId)).thenThrow(new ResourceNotFoundException("Uom not found, when: \"id = 999\"."));
+            when(statusService.findEntityById(statusId)).thenThrow(new ResourceNotFoundException("Uom not found, when: \"id = 999\"."));
 
             // When & Then
             assertThatThrownBy(() -> service.changeStatus(uomId, statusId))

--- a/src/test/java/com/elara/app/unit_of_measure_service/service/implementation/UomStatusServiceImpTest.java
+++ b/src/test/java/com/elara/app/unit_of_measure_service/service/implementation/UomStatusServiceImpTest.java
@@ -394,8 +394,8 @@ class UomStatusServiceImpTest {
         }
 
         @Test
-        @DisplayName("FindByIdService with existing id, returns UomStatus entity")
-        void findByIdService_withExistingId_returnsEntity() {
+        @DisplayName("FindEntityById with existing id, returns UomStatus entity")
+        void findEntityById_withExistingId_returnsEntity() {
             Long id = 1L;
             UomStatus entity = UomStatus.builder()
                 .id(id)
@@ -406,7 +406,7 @@ class UomStatusServiceImpTest {
 
             when(repository.findById(id)).thenReturn(Optional.of(entity));
 
-            UomStatus result = service.findByIdService(id);
+            UomStatus result = service.findEntityById(id);
 
             assertThat(result).isNotNull();
             assertThat(result.getId()).isEqualTo(id);
@@ -420,8 +420,8 @@ class UomStatusServiceImpTest {
         }
 
         @Test
-        @DisplayName("FindByIdService with non-existent id, throws ResourceNotFoundException")
-        void findByIdService_withNonExistentId_throwsResourceNotFoundException() {
+        @DisplayName("FindEntityById with non-existent id, throws ResourceNotFoundException")
+        void findEntityById_withNonExistentId_throwsResourceNotFoundException() {
             Long id = 999L;
             String errorMessage = "UomStatus with id '999' not found";
 
@@ -429,7 +429,7 @@ class UomStatusServiceImpTest {
             when(messageService.getMessage(eq("crud.not.found"), eq("UomStatus"), eq("id"), eq(id)))
                 .thenReturn(errorMessage);
 
-            assertThatThrownBy(() -> service.findByIdService(id))
+            assertThatThrownBy(() -> service.findEntityById(id))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining(errorMessage);
 
@@ -593,7 +593,7 @@ class UomStatusServiceImpTest {
 
             when(repository.existsByName(name)).thenReturn(true);
 
-            Boolean result = service.isNameTaken(name);
+            boolean result = service.isNameTaken(name);
 
             assertThat(result).isTrue();
             verify(repository).existsByName(name);
@@ -607,7 +607,7 @@ class UomStatusServiceImpTest {
 
             when(repository.existsByName(name)).thenReturn(false);
 
-            Boolean result = service.isNameTaken(name);
+            boolean result = service.isNameTaken(name);
 
             assertThat(result).isFalse();
             verify(repository).existsByName(name);


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the Unit of Measure (UOM) service, focusing on endpoint naming consistency, transactional annotation usage, method naming, and type consistency for boolean checks. The changes enhance code clarity, maintainability, and align the API with established conventions.

**API Endpoint and Naming Consistency:**

* Changed all UOM status-related API endpoints and references from `"states"` to `"status"` for clarity and consistency (e.g., `@RequestMapping`, example URLs in Swagger docs, and endpoint descriptions). [[1]](diffhunk://#diff-3624c507967548471b05ad92933388943a2f9fcd6203b7013fd44aa2541a6d91L32-R32) [[2]](diffhunk://#diff-3624c507967548471b05ad92933388943a2f9fcd6203b7013fd44aa2541a6d91L164-R164) [[3]](diffhunk://#diff-3624c507967548471b05ad92933388943a2f9fcd6203b7013fd44aa2541a6d91L198-R198) [[4]](diffhunk://#diff-3624c507967548471b05ad92933388943a2f9fcd6203b7013fd44aa2541a6d91L231-R231) [[5]](diffhunk://#diff-3624c507967548471b05ad92933388943a2f9fcd6203b7013fd44aa2541a6d91L261-R261) [[6]](diffhunk://#diff-3624c507967548471b05ad92933388943a2f9fcd6203b7013fd44aa2541a6d91L319-R319)
* Updated the `ENTITY_NAME` constant in `UomStatusController` from `"State"` to `"UomStatus"`.

**Transactional Annotation Improvements:**

* Replaced `jakarta.transaction.Transactional` with `org.springframework.transaction.annotation.Transactional` and added `@Transactional(readOnly = true)` to read-only service methods in both `UomServiceImp` and `UomStatusServiceImp` to ensure proper transaction management and optimize database access. [[1]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdL15-R20) [[2]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdR110) [[3]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdR131) [[4]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdR141) [[5]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdR151) [[6]](diffhunk://#diff-7640438f328a86a47a23d6f743e4855acb347c64eb92688e8fee89e46b4f255bL13-R18) [[7]](diffhunk://#diff-7640438f328a86a47a23d6f743e4855acb347c64eb92688e8fee89e46b4f255bL138-R138) [[8]](diffhunk://#diff-7640438f328a86a47a23d6f743e4855acb347c64eb92688e8fee89e46b4f255bR174) [[9]](diffhunk://#diff-7640438f328a86a47a23d6f743e4855acb347c64eb92688e8fee89e46b4f255bR191) [[10]](diffhunk://#diff-7640438f328a86a47a23d6f743e4855acb347c64eb92688e8fee89e46b4f255bR208)

**Method and Type Refactoring:**

* Standardized boolean existence checks to use the primitive `boolean` type instead of the boxed `Boolean` type in repository interfaces and service implementations for `existsByName` methods. [[1]](diffhunk://#diff-a625f98433140b6a652a23c65adfda0e66b24c614dda4a5827b774c17e6ffe1dL18-R18) [[2]](diffhunk://#diff-2952b61173415e5530c2409e6d99c3eba598fbc9681b27c5c72852b86495d7fbL20-R20) [[3]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdL43-R49) [[4]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdL73-R73) [[5]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdL157-R164) [[6]](diffhunk://#diff-7640438f328a86a47a23d6f743e4855acb347c64eb92688e8fee89e46b4f255bL53-R53) [[7]](diffhunk://#diff-7640438f328a86a47a23d6f743e4855acb347c64eb92688e8fee89e46b4f255bL92-R92)
* Renamed `findByIdService` method to `findEntityById` in `UomStatusServiceImp` and updated all usages to improve clarity and intent. [[1]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdL43-R49) [[2]](diffhunk://#diff-392de33f7bdc754210460c732656804e384d12aef6a228d2d564d4d3ff1000cdL177-R181) [[3]](diffhunk://#diff-7640438f328a86a47a23d6f743e4855acb347c64eb92688e8fee89e46b4f255bR152-R155)

**Model Validation:**

* Added `@NotNull` annotation to the `uomStatus` field in the `Uom` entity to enforce that every UOM must have a status.