### PR TITLE
Add DeepWiki Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/elara-app/unit-of-measure-service)
+
 # Unit of Measure Service
 
 Spring Boot microservice for unit of measure catalog and status governance within a distributed platform.


### PR DESCRIPTION
This pull request adds a DeepWiki badge to the `README.md` file to provide quick access to documentation and support resources for the Unit of Measure Service.

Documentation and support:

* Added a DeepWiki badge at the top of `README.md` to link directly to the service's DeepWiki page.